### PR TITLE
Add validation rules for many properties

### DIFF
--- a/CountPulsesStep.py
+++ b/CountPulsesStep.py
@@ -46,6 +46,9 @@ class CountPulsesStep(TestStep):
     def __init__(self):
         super(CountPulsesStep, self).__init__()
 
+        self.Rules.Add(
+            Rule("interval", lambda: not self.block or self.interval >= 0, lambda: 'Interval must not be negative.'))
+
     def Run(self):
         super().Run()  # 3.0: Required for debugging to work.
 

--- a/GenerateSineWave.py
+++ b/GenerateSineWave.py
@@ -30,6 +30,11 @@ class GenerateSineWave(TestStep):
     def __init__(self):
         super(GenerateSineWave, self).__init__()
 
+        self.Rules.Add(
+            Rule("Frequency", lambda: self.Frequency >= 0.1, lambda: 'Frequency must be at least 0.1 Hz.'))
+        self.Rules.Add(
+            Rule("Frequency", lambda: self.Frequency < 4000000, lambda: 'Frequency must be lower than 4000000 Hz.'))
+
     def Run(self):
         super().Run()  # 3.0: Required for debugging to work.
 

--- a/GenerateSquareWave.py
+++ b/GenerateSquareWave.py
@@ -33,6 +33,15 @@ class GenerateSquareWave(TestStep):
     def __init__(self):
         super(GenerateSquareWave, self).__init__()
 
+        self.Rules.Add(
+            Rule("Frequency", lambda: self.Frequency >= 4, lambda: 'Frequency must be at least 4 Hz.'))
+        self.Rules.Add(
+            Rule("Frequency", lambda: self.Frequency <= 10000000, lambda: 'Frequency must not exceed 10000000 Hz.'))
+        self.Rules.Add(
+            Rule("Duty_Cycles", lambda: self.Duty_Cycles >= 0.0, lambda: 'Duty Cycle must not be negative.'))
+        self.Rules.Add(
+            Rule("Duty_Cycles", lambda: self.Duty_Cycles <= 1.0, lambda: 'Duty Cycle must not exceed 1.'))
+
     def Run(self):
         super().Run()  # 3.0: Required for debugging to work.
 

--- a/LogicAnalyzerCaptureStep.py
+++ b/LogicAnalyzerCaptureStep.py
@@ -46,6 +46,12 @@ class LogicAnalyzerCaptureStep(TestStep):
     def __init__(self):
         super(LogicAnalyzerCaptureStep, self).__init__()
 
+        self.Rules.Add(
+            Rule("timeout", lambda: not self.block or self.timeout >= 0, lambda: 'Timeout must not be negative.'))
+        self.Rules.Add(Rule("events", lambda: self.events >= 0, lambda: 'Number of events must not be negative.'))
+        self.Rules.Add(
+            Rule("events", lambda: self.events <= 2500, lambda: 'Number of events cannot be greater than 2500.'))
+
     def Run(self):
         super().Run()  # 3.0: Required for debugging to work.
 

--- a/MeasureDutyCycleStep.py
+++ b/MeasureDutyCycleStep.py
@@ -23,6 +23,8 @@ class MeasureDutyCycleStep(TestStep):
     def __init__(self):
         super(MeasureDutyCycleStep, self).__init__()
 
+        self.Rules.Add(Rule("timeout", lambda: self.timeout >= 0, lambda: 'Timeout must not be negative.'))
+
     def Run(self):
         super().Run()  # 3.0: Required for debugging to work.
 

--- a/MeasureFrequencyStep.py
+++ b/MeasureFrequencyStep.py
@@ -34,6 +34,8 @@ class MeasureFrequencyStep(TestStep):
     def __init__(self):
         super(MeasureFrequencyStep, self).__init__()
 
+        self.Rules.Add(Rule("timeout", lambda: self.timeout >= 0, lambda: 'Timeout must not be negative.'))
+
     def Run(self):
         super().Run()  # 3.0: Required for debugging to work.
 

--- a/MeasureIntervalStep.py
+++ b/MeasureIntervalStep.py
@@ -57,6 +57,8 @@ class MeasureIntervalStep(TestStep):
     def __init__(self):
         super(MeasureIntervalStep, self).__init__()
 
+        self.Rules.Add(Rule("timeout", lambda: self.timeout >= 0, lambda: 'Timeout must not be negative.'))
+
     def Run(self):
         super().Run()  # 3.0: Required for debugging to work.
 

--- a/MeasureRMSVoltageStep.py
+++ b/MeasureRMSVoltageStep.py
@@ -57,6 +57,10 @@ class MeasureRMSVoltage(TestStep):
     def __init__(self):
         super(MeasureRMSVoltage, self).__init__()
 
+        self.Rules.Add(Rule("PreDelay", lambda: self.PreDelay >= 0, lambda: 'PreDelay must not be negative.'))
+        self.Rules.Add(Rule("Frequency", lambda: self.Frequency > 0, lambda: 'Frequency must be positive.'))
+        self.Rules.Add(Rule("Frequency", lambda: self.Frequency <= 31250, lambda: 'Frequency must not exceed 31250 Hz.'))
+
     def Run(self):
         super().Run()  # 3.0: Required for debugging to work.
 

--- a/SetCurrentStep.py
+++ b/SetCurrentStep.py
@@ -23,6 +23,9 @@ class SetCurrentStep(TestStep):
     def __init__(self):
         super(SetCurrentStep, self).__init__()
 
+        self.Rules.Add(Rule("Current", lambda: self.Current >= 0, lambda: 'Current must not be negative.'))
+        self.Rules.Add(Rule("Current", lambda: self.Current <= 3.3e-3, lambda: f'Current must not exceed {3.3e-3} A.'))
+
     def Run(self):
         self.PowerSupply.setPcs(self.Current)
         self.UpgradeVerdict(Verdict.Pass)

--- a/SetVoltageStep.py
+++ b/SetVoltageStep.py
@@ -25,6 +25,35 @@ class SetVoltageStep(TestStep):
     def __init__(self):
         super(SetVoltageStep, self).__init__()
 
+        self.Rules.Add(
+            Rule("Voltage", lambda: self.Voltage >= self.get_min_voltage(),
+                 lambda: f'Voltage must be at least {self.get_min_voltage()} V for {self.Pin}.'))
+        self.Rules.Add(
+            Rule("Voltage", lambda: self.Voltage <= self.get_max_voltage(),
+                 lambda: f'Voltage must not exceed {self.get_max_voltage()} V for {self.Pin}.'))
+
     def Run(self):
         self.PowerSupply.setVoltage(self.Pin, self.Voltage)
         self.UpgradeVerdict(Verdict.Pass)
+
+    def get_min_voltage(self):
+        """Gets minimal voltage for current pin."""
+        match self.Pin:
+            case PowerPin.ONE:
+                return -5
+            case PowerPin.TWO:
+                return -3.3
+            case PowerPin.THREE:
+                return 0
+            case _:
+                raise Exception(f"Unsupported pin: {self.Pin}")
+
+    def get_max_voltage(self):
+        """Gets maximum voltage for current pin."""
+        match self.Pin:
+            case PowerPin.ONE:
+                return 5
+            case PowerPin.TWO | PowerPin.THREE:
+                return 3.3
+            case _:
+                raise Exception(f"Unsupported pin: {self.Pin}")


### PR DESCRIPTION
Tests may fail if properties are set to values which are not supported by the PSLab hardware. I have added validation rules which will trigger warnings if unsupported values are used.

Support for validation rules was broken in Opentap.Python previous to version 3.0.2, but is fixed now.